### PR TITLE
fix: use RedisURI for exporter configuration

### DIFF
--- a/exporter/src/main/java/io/zeebe/redis/exporter/ExporterConfiguration.java
+++ b/exporter/src/main/java/io/zeebe/redis/exporter/ExporterConfiguration.java
@@ -1,5 +1,7 @@
 package io.zeebe.redis.exporter;
 
+import io.lettuce.core.RedisURI;
+
 import java.time.Duration;
 import java.util.Optional;
 
@@ -56,10 +58,11 @@ public class ExporterConfiguration {
     return getEnv("NAME").orElse(name);
   }
 
-  public Optional<String> getRemoteAddress() {
+  public Optional<RedisURI> getRemoteAddress() {
     return getEnv("REMOTE_ADDRESS")
             .or(() -> Optional.ofNullable(remoteAddress))
-            .filter(remoteAddress -> !remoteAddress.isEmpty());
+            .filter(remoteAddress -> !remoteAddress.isEmpty())
+            .map(RedisURI::create);
   }
 
   private Optional<String> getEnv(String name) {


### PR DESCRIPTION
# Issue
Logging connection string could leak credentials of the redis connection.

https://github.com/camunda-community-hub/zeebe-redis-exporter/blob/2fa03969ef7c25bd17957b1a87ca9f3791f23351/exporter/src/main/java/io/zeebe/redis/exporter/RedisExporter.java#L96

# Solution
Use [Lettuce RedisURI](https://javadoc.io/static/io.lettuce/lettuce-core/6.2.5.RELEASE/io/lettuce/core/RedisURI.html) class to parse redis remote address.
This has the benefit of having [URI assertions](https://github.com/lettuce-io/lettuce-core/blob/45a51436a8ece78d672327dffa89927901558936/src/main/java/io/lettuce/core/RedisURI.java#L295) as well as [credential masking in the toString method](https://github.com/lettuce-io/lettuce-core/blob/45a51436a8ece78d672327dffa89927901558936/src/main/java/io/lettuce/core/RedisURI.java#L976).