### PR TITLE
Fix null redisClient during validation, add more logs

### DIFF
--- a/exporter/src/main/java/io/zeebe/redis/exporter/RedisExporter.java
+++ b/exporter/src/main/java/io/zeebe/redis/exporter/RedisExporter.java
@@ -88,16 +88,22 @@ public class RedisExporter implements Exporter {
   @Override
   public void open(Controller controller) {
     if (config.getRemoteAddress().isEmpty()) {
+      logger.error("Redis configuration error: Missing remote address. Please check ZEEBE_REDIS_REMOTE_ADDRESS environment variable or configuration.");
       throw new IllegalStateException("Missing ZEEBE_REDIS_REMOTE_ADDRESS configuration.");
     }
     this.controller = controller;
 
+    logger.info("Initializing Redis client with configuration: useClusterClient={}, ioThreadPoolSize={}, remoteAddress={}",
+            config.isUseClusterClient(), config.getIoThreadPoolSize(), config.getRemoteAddress().get());
+
     if (config.isUseClusterClient()) {
+        logger.debug("Creating Redis cluster client...");
         var clusterClient = RedisClusterClient.create(
                 ClusterClientSettings.createResourcesFromConfig(config), config.getRemoteAddress().get());
         clusterClient.setOptions(ClusterClientSettings.createStandardOptions());
         redisClient = new UniversalRedisClient(clusterClient);
     } else {
+        logger.debug("Creating Redis standalone client...");
         redisClient = new UniversalRedisClient(RedisClient.create(
                 ClientResources.builder().ioThreadPoolSize(config.getIoThreadPoolSize()).build(),
                 config.getRemoteAddress().get()));
@@ -109,27 +115,39 @@ public class RedisExporter implements Exporter {
     boolean failure = false;
     // try to connect
     try {
+      logger.info("Attempting to establish Redis connection to {}", config.getRemoteAddress().get());
       senderConnection = useProtoBuf ? redisClient.connect(new ProtobufCodec()) : redisClient.connect();
       cleanupConnection = useProtoBuf ? redisClient.connect(new ProtobufCodec()) : redisClient.connect();
-      logger.info("Successfully connected Redis exporter to {}", config.getRemoteAddress().get());
+      logger.info("Successfully connected Redis exporter to {} using {} format", 
+              config.getRemoteAddress().get(), 
+              useProtoBuf ? "protobuf" : "json");
     } catch (RedisConnectionException ex) {
       if (!fullyLoggedStartupException) {
-        logger.error("Failure connecting Redis exporter to " + config.getRemoteAddress().get(), ex);
+        logger.error("Redis connection error: Failed to connect to {}. Error details: {}", 
+                config.getRemoteAddress().get(), ex.getMessage(), ex);
+        logger.error("Current Redis configuration: useClusterClient={}, ioThreadPoolSize={}, format={}", 
+                config.isUseClusterClient(), config.getIoThreadPoolSize(), 
+                useProtoBuf ? "protobuf" : "json");
         fullyLoggedStartupException = true;
       } else {
-        logger.warn("Failure connecting Redis exporter to {}: {}", config.getRemoteAddress().get(), ex.getMessage());
+        logger.warn("Redis connection retry failed for {}: {}", 
+                config.getRemoteAddress().get(), ex.getMessage());
       }
       failure = true;
     }
 
     // upon successful connection initialize the sender
     if (redisSender == null && senderConnection != null) {
+      logger.debug("Initializing Redis sender with batch size {} and cycle {} ms", 
+              config.getBatchSize(), config.getBatchCycleMillis());
       redisSender = new RedisSender(config, controller, senderConnection, logger);
       senderThread.schedule(this::sendBatches, config.getBatchCycleMillis(), TimeUnit.MILLISECONDS);
     }
 
     // always initialize the cleaner
     if (redisCleaner == null) {
+      logger.debug("Initializing Redis cleaner with cleanup cycle {} seconds", 
+              config.getCleanupCycleInSeconds());
       redisCleaner = new RedisCleaner(cleanupConnection, useProtoBuf, config, logger);
       if (config.getCleanupCycleInSeconds() > 0 &&
               (config.isDeleteAfterAcknowledge() || config.getMaxTimeToLiveInSeconds() > 0)) {
@@ -137,6 +155,7 @@ public class RedisExporter implements Exporter {
       }
     // upon late successful connection propagate it to cleaner
     } else if (cleanupConnection != null) {
+      logger.debug("Updating Redis cleaner with new connection");
       redisCleaner.setRedisConnection(cleanupConnection);
     }
 
@@ -146,8 +165,10 @@ public class RedisExporter implements Exporter {
         startupThread = Executors.newSingleThreadScheduledExecutor();
       }
       int delay = reconnectIntervals.size() > 1 ? reconnectIntervals.remove(0) : reconnectIntervals.get(0);
+      logger.info("Scheduling Redis connection retry in {} seconds", delay);
       startupThread.schedule(this::connectToRedis, delay, TimeUnit.SECONDS);
     } else if (startupThread != null ) {
+      logger.info("Connection successful, shutting down retry mechanism");
       startupThread.shutdown();
       startupThread = null;
     }
@@ -165,7 +186,13 @@ public class RedisExporter implements Exporter {
       cleanupConnection.close();
       cleanupConnection = null;
     }
-    redisClient.shutdown();
+    if (redisClient != null) {
+      redisClient.shutdown();
+    }
+    if (startupThread != null) {
+      startupThread.shutdown();
+      startupThread = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
I've noticed a bug in RedisExporter - it is trying to do this:

During exporter validation, Zeebe tries to test the lifecycle methods of the exporter
The validation process was calling close() without first calling open()
This led to redisClient being null when close() was called